### PR TITLE
[WIP] Bug/381 sortupdate event index wrong (#391)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ sortable('.sortable')[0].addEventListener('sortstart', function(e) {
 
     This event is triggered when the user starts sorting and the DOM position has not yet changed.
 
-    e.detail.item contains the current dragged element
-    e.detail.placeholder contains the placeholder element
-    e.detail.startparent contains the element that the dragged item comes from
-
+    e.detail.item - {HTMLElement} dragged element
+    
+    Origin Container Data
+    e.detail.origin.index - {Integer} Index of the element within Sortable Items Only
+    e.detail.origin.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
+    e.detail.origin.container - {HTMLElement} Sortable Container that element was moved out of (or copied from)
     */
 });
 ```
@@ -95,11 +97,14 @@ Use the `sortstop` event if you want to do something when sorting stops:
 sortable('.sortable')[0].addEventListener('sortstop', function(e) {
     /*
 
-    This event is triggered when the user stops sorting. The DOM position may have changed.
+    This event is triggered when the user stops sorting and the DOM position has not yet changed.
 
-    e.detail.item - contains the element that was dragged.
-    e.detail.startParent - contains the element that the dragged item came from.
-
+    e.detail.item - {HTMLElement} dragged element
+    
+    Origin Container Data
+    e.detail.origin.index - {Integer} Index of the element within Sortable Items Only
+    e.detail.origin.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
+    e.detail.origin.container - {HTMLElement} Sortable Container that element was moved out of (or copied from)
     */
 });
 ```
@@ -110,20 +115,27 @@ Use `sortupdate` event if you want to do something when the order changes (e.g. 
 
 ``` javascript
 sortable('.sortable')[0].addEventListener('sortupdate', function(e) {
+
+    console.log(e.detail);
+
     /*
-
     This event is triggered when the user stopped sorting and the DOM position has changed.
-
-    e.detail.item - contains the current dragged element.
-    e.detail.startSortableIndex - contains the initial index of the dragged element in sortable list items (see Options => Items)
-    e.detail.endSortableIndex - contains the new index of the dragged element sortable list items (see Options => Items)
-    e.detail.startIndex - contains the initial index of the dragged element in all list items (including non-sortable ones)
-    e.detail.endIndex - contains the new index of the dragged element in all list items (including non-sortable ones)
-    e.detail.startParent - contains the element that the dragged item comes from
-    e.detail.endParent - contains the element that the dragged item was added to (new parent)
-    e.detail.newEndList - contains all elements in the list the dragged item was dragged to
-    e.detail.newStartList - contains all elements in the list the dragged item was dragged from
-    e.detail.oldStartList - contains all elements in the list the dragged item was dragged from BEFORE it was dragged from it
+     
+    e.detail.item - {HTMLElement} dragged element
+    
+    Origin Container Data
+    e.detail.origin.index - {Integer} Index of the element within Sortable Items Only
+    e.detail.origin.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
+    e.detail.origin.container - {HTMLElement} Sortable Container that element was moved out of (or copied from)
+    e.detail.origin.itemsBeforeUpdate - {Array} Sortable Items before the move
+    e.detail.origin.items - {Array} Sortable Items after the move
+    
+    Destination Container Data
+    e.detail.destination.index - {Integer} Index of the element within Sortable Items Only
+    e.detail.destination.elementIndex - {Integer} Index of the element in all elements in the Sortable Container
+    e.detail.destination.container - {HTMLElement} Sortable Container that element was moved out of (or copied from)
+    e.detail.destination.itemsBeforeUpdate - {Array} Sortable Items before the move
+    e.detail.destination.items - {Array} Sortable Items after the move
     */
 });
 ```

--- a/__tests__/events.test.ts
+++ b/__tests__/events.test.ts
@@ -7,11 +7,11 @@ describe('Testing events', () => {
 
   let getIndex = (item, NodeList) => Array.prototype.indexOf.call(NodeList, item)
   let ul, li, secondLi, ul2, fifthLi, fourthLi
-  var sortstartitem, sortstartStartParent
-  var sortupdateitem, sortupdateitemEndIndex, sortupdateitemStartIndex, sortupdateitemStartSortableIndex,
+  let startEventOriginItem, startEventOriginContainer
+  let sortupdateitem, sortupdateitemEndIndex, sortupdateitemStartIndex, sortupdateitemStartSortableIndex,
     sortupdateitemEndSortableIndex, sortupdateitemStartParent, sortupdateitemEndParent,
     sortupdateitemNewEndList, sortupdateitemNewStartList, sortupdateitemOldStartList
-  var sortstopitem, sortstopStartparent
+  let sortstopitem, sortstopStartparent
 
   let dataTransferObj
 
@@ -56,8 +56,8 @@ describe('Testing events', () => {
       }]
     }
 
-    sortstartitem = null
-    sortstartStartParent = null
+    startEventOriginItem = null
+    startEventOriginContainer = null
 
     sortupdateitem = null
     sortupdateitemEndIndex = null
@@ -82,8 +82,8 @@ describe('Testing events', () => {
 
   function addEventListener (ul) {
     sortable(ul, null)[0].addEventListener('sortstart', function (e) {
-      sortstartitem = e.detail.item
-      sortstartStartParent = e.detail.startParent
+      startEventOriginItem = e.detail.item
+      startEventOriginContainer = e.detail.origin.container
     })
     sortable(ul, null)[0].addEventListener('sortupdate', function (e) {
       sortupdateitem = e.detail.item
@@ -120,8 +120,8 @@ describe('Testing events', () => {
     expect(li.getAttribute('aria-grabbed')).toEqual('true')
     expect(li.classList.contains('test-dragging')).toBe(true)
 
-    expect(sortstartitem).toEqual(li)
-    expect(ul).toEqual(sortstartStartParent)
+    expect(startEventOriginItem).toEqual(li)
+    expect(ul).toEqual(startEventOriginContainer)
     expect(null).toEqual(sortupdateitem)
     expect(null).toEqual(sortstopitem)
   })
@@ -244,8 +244,8 @@ describe('Testing events', () => {
     expect(getIndex(li, ul.children)).not.toEqual(originalIndex)
     expect(getIndex(li, ul.children)).toEqual(1)
 
-    expect(sortstartitem).toEqual(li)
-    expect(ul).toEqual(sortstartStartParent)
+    expect(startEventOriginItem).toEqual(li)
+    expect(ul).toEqual(startEventOriginContainer)
 
     expect(li).toEqual(sortupdateitem)
     expect(1).toEqual(sortupdateitemEndIndex)

--- a/docs/index.html
+++ b/docs/index.html
@@ -361,13 +361,13 @@
 			     <p>Item 1-6 are allows to be sorted with Item 7-12 but not the other way around.</p>
 					<div class="mt2 p2 bg-navy border yellow border-yellow">
 				    <code class="mb0">
-							<div>sortable('.o-sortable1', {</div>
-							<div>acceptFrom: false (accept from no one)</div>
-							<div>});</div>
-							<div>sortable('.o-sortable2', {</div>
-							<div>acceptFrom: '.o-sortable1' (accept from .o-sortable1)</div>
-							<div>});</div>
-						</code>
+						<div>sortable('.o-sortable1', {</div>
+						<div>acceptFrom: false (accept from no one)</div>
+						<div>});</div>
+						<div>sortable('.o-sortable2', {</div>
+						<div>acceptFrom: '.o-sortable1' (accept from .o-sortable1)</div>
+						<div>});</div>
+					</code>
   				</div>
 		    </div>
 			    <div class="col col-3">
@@ -416,125 +416,125 @@
 		</section>
 		<section class="mb3 mx-auto col col-12">
   		<div class="p3 clearfix bg-yellow maroon">
-				<div class="col col-12 mb1">
-			    <h2 class="h3 m0">Sortable Copy</h2>
-				</div>
-				<div class="col col-6">
-					<div class="p2 bg-yellow border maroon border-maroon mt1">
-				    <code class="mb0">
-							<div>sortable('.o-sortable', {</div>
-							<div class="px2 muted">copy:true // default to false</div>
-							<div>});</div>
-						</code>
-  				</div>
-					<h2 class="h4 mt1">Copy items here</h2>
-					<ul class="p2 border maroon border-maroon js-sortable-copy-target sortable list flex flex-column list-reset">
-					</ul>
-		    </div>
-				<div class="col col-6">
-						<ul class="ml4 js-sortable-copy sortable list flex flex-column list-reset">
-							<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 1</li>
-							<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 2</li>
-							<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 3</li>
-							<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 4</li>
-							<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 5</li>
-							<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 6</li>
-						</ul>
-			    </div>
-		    </div>
+			<div class="col col-12 mb1">
+			<h2 class="h3 m0">Sortable Copy</h2>
+			</div>
+			<div class="col col-6">
+				<div class="p2 bg-yellow border maroon border-maroon mt1">
+				<code class="mb0">
+					<div>sortable('.o-sortable', {</div>
+					<div class="px2 muted">copy:true // default to false</div>
+					<div>});</div>
+				</code>
+			</div>
+				<h2 class="h4 mt1">Copy items here</h2>
+				<ul class="p2 border maroon border-maroon js-sortable-copy-target sortable list flex flex-column list-reset">
+				</ul>
+		</div>
+			<div class="col col-6">
+				<ul class="ml4 js-sortable-copy sortable list flex flex-column list-reset">
+					<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 1</li>
+					<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 2</li>
+					<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 3</li>
+					<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 4</li>
+					<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 5</li>
+					<li class="p1 mb1 yellow bg-maroon" style="position: relative; z-index: 10">Item 6</li>
+				</ul>
+			</div>
 		</div>
 		</section>
 	</div>
 	<script>
-	sortable('.js-sortable-copy', {
-      forcePlaceholderSize: true,
-      copy: true,
-			acceptFrom: false,
-      placeholderClass: 'mb1 bg-navy border border-yellow',
-    });
-	sortable('.js-sortable-copy-target', {
-    forcePlaceholderSize: true,
-		acceptFrom: '.js-sortable-copy,.js-sortable-copy-target',
-    placeholderClass: 'mb1 border border-maroon',
-  });
-    sortable('.js-grid', {
-				forcePlaceholderSize: true,
-				placeholderClass: 'col col-4 border border-maroon'
-			});
-			sortable('.js-sortable-connected', {
-				forcePlaceholderSize: true,
-				connectWith: '.js-connected',
-				handle: '.js-handle',
-				items: 'li',
-				placeholderClass: 'border border-white bg-orange mb1'
-			});
-			sortable('.js-sortable-inner-connected', {
-				forcePlaceholderSize: true,
-				connectWith: 'js-inner-connected',
-				handle: '.js-inner-handle',
-				items: '.item',
-        maxItems: 3,
-				placeholderClass: 'border border-white bg-orange mb1'
-			});
-			document.querySelector('.js-sortable-connected').addEventListener('sortupdate', function(e){
-        console.log('Sortupdate: ', e.detail);
-                console.log('Parent: ', e.detail.startParent, ' -> ', e.detail.endParent);
-                console.log('Index: '+e.detail.startIndex+' -> '+e.detail.endIndex);
-                console.log('sortableIndex: '+e.detail.startSortableIndex+' -> '+e.detail.endSortableIndex);
-			});
+		sortable('.js-sortable-copy', {
+		  forcePlaceholderSize: true,
+		  copy: true,
+				acceptFrom: false,
+		  placeholderClass: 'mb1 bg-navy border border-yellow',
+		});
+		sortable('.js-sortable-copy-target', {
+		forcePlaceholderSize: true,
+			acceptFrom: '.js-sortable-copy,.js-sortable-copy-target',
+		placeholderClass: 'mb1 border border-maroon',
+	  });
+		sortable('.js-grid', {
+					forcePlaceholderSize: true,
+					placeholderClass: 'col col-4 border border-maroon'
+				});
+		sortable('.js-sortable-connected', {
+			forcePlaceholderSize: true,
+			connectWith: '.js-connected',
+			handle: '.js-handle',
+			items: 'li',
+			placeholderClass: 'border border-white bg-orange mb1'
+		});
+		sortable('.js-sortable-inner-connected', {
+			forcePlaceholderSize: true,
+			connectWith: 'js-inner-connected',
+			handle: '.js-inner-handle',
+			items: '.item',
+	maxItems: 3,
+			placeholderClass: 'border border-white bg-orange mb1'
+		});
+		document.querySelector('.js-sortable-connected').addEventListener('sortupdate', function(e){
+			console.log('Sortupdate: ', e.detail);
+			console.log('Container: ', e.detail.origin.container, ' -> ', e.detail.destination.container);
+			console.log('Index: '+e.detail.origin.index+' -> '+e.detail.destination.index);
+			console.log('Element Index: '+e.detail.origin.elementIndex+' -> '+e.detail.destination.elementIndex);
+		});
 
-      document.querySelector('.js-sortable-connected').addEventListener('sortstart', function(e){
-        console.log('Sortstart: ', e.detail);
-      });
+		document.querySelector('.js-sortable-connected').addEventListener('sortstart', function(e){
+			console.log('Sortstart: ', e.detail);
+		});
 
-      document.querySelector('.js-sortable-connected').addEventListener('sortstop', function(e){
-        console.log('Sortstop: ', e.detail);
-      });
+		document.querySelector('.js-sortable-connected').addEventListener('sortstop', function(e){
+			console.log('Sortstop: ', e.detail);
+		});
 
+		sortable('.js-sortable-buttons', {
+			forcePlaceholderSize: true,
+			items: 'li',
+			placeholderClass: 'border border-white mb1'
+		});
+		// buttons to add items and reload the list
+		// separately to showcase issue without reload
+		document.querySelector('.js-add-item-button').addEventListener('click', function(){
+			doc = new DOMParser().parseFromString(`<li class="p1 mb1 blue bg-white">new item</li>`, "text/html").body.firstChild;
+			document.querySelector('.js-sortable-buttons').appendChild(doc);
+		});
+
+		document.querySelector('.js-reload').addEventListener('click', function(){
+			console.log('Options before re-init:');
+			console.log(document.querySelector('.js-sortable-buttons').h5s.data.opts);
+			sortable('.js-sortable-buttons');
+			console.log('Options after re-init:');
+			console.log(document.querySelector('.js-sortable-buttons').h5s.data.opts);
+		});
+		// JS DISABLED
+		document.querySelector('.js-disable').addEventListener('click', function(){
+			var $list = document.querySelector('[data-disabled]');
+			if ( $list.getAttribute('data-disabled') === 'false' ) {
+				this.innerHTML = 'Enable';
+				sortable($list, 'disable');
+				$list.setAttribute('data-disabled', true);
+				$list.classList.add('muted');
+			} else {
+				this.innerHTML = 'Disable';
+				sortable($list, 'enable');
+				$list.setAttribute('data-disabled', false);
+				$list.classList.remove('muted');
+			}
+		});
+
+		// Destroy & Init
+		document.querySelector('.js-destroy').addEventListener('click', function(){
+			sortable('.js-sortable-buttons', 'destroy');
+		});
+		document.querySelector('.js-init').addEventListener('click', function(){
 			sortable('.js-sortable-buttons', {
 				forcePlaceholderSize: true,
 				items: 'li',
 				placeholderClass: 'border border-white mb1'
 			});
-			// buttons to add items and reload the list
-			// separately to showcase issue without reload
-			document.querySelector('.js-add-item-button').addEventListener('click', function(){
-        doc = new DOMParser().parseFromString(`<li class="p1 mb1 blue bg-white">new item</li>`, "text/html").body.firstChild;
-				document.querySelector('.js-sortable-buttons').appendChild(doc);
-			});
-			document.querySelector('.js-reload').addEventListener('click', function(){
-				console.log('Options before re-init:');
-				console.log(document.querySelector('.js-sortable-buttons').h5s.data.opts);
-				sortable('.js-sortable-buttons');
-				console.log('Options after re-init:');
-				console.log(document.querySelector('.js-sortable-buttons').h5s.data.opts);
-			});
-			// JS DISABLED
-			document.querySelector('.js-disable').addEventListener('click', function(){
-				var $list = document.querySelector('[data-disabled]');
-				if( $list.getAttribute('data-disabled') === 'false' )
-				{
-          this.innerHTML = 'Enable';
-					sortable($list, 'disable');
-					$list.setAttribute('data-disabled', true);
-					$list.classList.add('muted');
-				} else {
-          this.innerHTML = 'Disable';
-					sortable($list, 'enable');
-					$list.setAttribute('data-disabled', false);
-					$list.classList.remove('muted');
-				}
-			});
-			// Destroy & Init
-			document.querySelector('.js-destroy').addEventListener('click', function(){
-				sortable('.js-sortable-buttons', 'destroy');
-			});
-			document.querySelector('.js-init').addEventListener('click', function(){
-				sortable('.js-sortable-buttons', {
-					forcePlaceholderSize: true,
-					items: 'li',
-					placeholderClass: 'border border-white mb1'
-				});
-			});
+		});
 	</script>
 </body>


### PR DESCRIPTION
* Quick fix to wrong sortable index - local cache of sortable items is refreshed on dragstart event

Custom Event results update - fixes #281 & #381

Code comments

Prevent processing of non-sortable elements on dragover

Logical flip of an expected boolean return

* README update, along with use of dragenter

* Add updated Docs in HTML and js to run docs

* Added a missing removal of placeholder onDrop outside of a valid target & and unstaged /docs/html5sortable.js - until it is release ready

* Removing unnecessary code after a rebase to the latest master

* Making Travis happy - removing unnecessary whitespaces from around parameters passed on to a function

* Only attempt to remove placeholder if it IS there